### PR TITLE
Adding test dir npm package install to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ADD install-osm2pgsql.sh /oync/
 ADD "Gemfile" "Gemfile.lock" /oync/
 
 WORKDIR /oync
+
 # install dependencies
 RUN bash install-osm2pgsql.sh
 RUN bash install-oync.sh
@@ -55,3 +56,9 @@ ADD empty.osm /oync/
 ADD oync.style /oync/
 ADD oync_schema.sql /oync/
 ADD clear.sql /oync/
+
+# install npm modules
+WORKDIR /oync/test
+RUN npm install
+
+WORKDIR /oync

--- a/test/README.md
+++ b/test/README.md
@@ -4,8 +4,8 @@ Scripts and data for testing oync.
 
 Install requirements and start mock test server (node express app):
 ```
-# (prereq) install node on system
-npm install express
+# (prereq) install node and required packages
+npm install
 node test-server.js
 ```
 

--- a/test/package.json
+++ b/test/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.13.3"
+    "express": "^4.13.4",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Otherwise docker build wouldn't build a working image upon checking out repo (was working only because I had the test/node_modules created when I built the docker image locally).  
